### PR TITLE
Fixed Player Still Has Control On Game Over

### DIFF
--- a/src/characters/player/_movement.gd
+++ b/src/characters/player/_movement.gd
@@ -51,6 +51,7 @@ func physics_process(delta: float):
 	
 	# Debug Reset
 	if Input.is_action_pressed("reset"):
+		GlobalFlags.IS_GAME_OVER = false
 		var _ret = get_tree().reload_current_scene()
 	elif Input.is_action_pressed("quit"):
 		get_tree().quit()

--- a/src/characters/playercrashing.gd
+++ b/src/characters/playercrashing.gd
@@ -8,7 +8,9 @@ func enter(_msg: Dictionary = {}):
 	_actor.exhaust_sprite.visible = false
 	# Wait a bit and turn the engine back on
 	yield(get_tree().create_timer(0.6),"timeout")
-	GlobalFlags.IS_PLAYER_CONTROLLABLE = true
+	# Hackity hack hack
+	if not GlobalFlags.IS_GAME_OVER:
+		GlobalFlags.IS_PLAYER_CONTROLLABLE = true
 	exit()
 
 

--- a/src/ui/GameOver.tscn
+++ b/src/ui/GameOver.tscn
@@ -35,7 +35,7 @@ size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="CenterContainer"]
 margin_right = 376.0
-margin_bottom = 286.0
+margin_bottom = 228.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -68,13 +68,12 @@ valign = 1
 [node name="CenterContainer3" type="CenterContainer" parent="CenterContainer/VBoxContainer"]
 margin_top = 173.0
 margin_right = 376.0
-margin_bottom = 286.0
+margin_bottom = 228.0
 
 [node name="Label" type="Label" parent="CenterContainer/VBoxContainer/CenterContainer3"]
 margin_left = 74.0
 margin_right = 302.0
-margin_bottom = 113.0
+margin_bottom = 55.0
 custom_fonts/font = SubResource( 4 )
-text = "R to restart
-Q to quit"
+text = "R to restart"
 valign = 1

--- a/src/ui/countdown_timer.gd
+++ b/src/ui/countdown_timer.gd
@@ -5,7 +5,7 @@ signal game_over
 onready var timer = $Timer
 onready var label = $CountdownLabel
 
-export (int) var start_time = 120
+export (int) var start_time = 5
 
 
 func _ready():

--- a/src/utils/CountdownTimer.gd
+++ b/src/utils/CountdownTimer.gd
@@ -14,6 +14,7 @@ func _add_time(value):
 
 func game_over():
 	GlobalFlags.IS_PLAYER_CONTROLLABLE = false
+	GlobalFlags.IS_GAME_OVER = true
 	
 	run_end_time = OS.get_unix_time()
 	var run_time = run_end_time - run_start_time

--- a/src/utils/GlobalFlags.gd
+++ b/src/utils/GlobalFlags.gd
@@ -1,6 +1,7 @@
 extends Node
 
 
+var IS_GAME_OVER = false
 var IS_PLAYER_CONTROLLABLE = true
 var CAN_SHOP = false
 


### PR DESCRIPTION
The reason was when the player hit game over in the crashed state, the enter logic in that state re-enabled controls.